### PR TITLE
fix: プレイヤーの当たり判定を中央2x2ピクセルに縮小

### DIFF
--- a/game.js
+++ b/game.js
@@ -52,10 +52,15 @@ class Obstacle {
     }
 
     collidesWith(player) {
-        return player.x < this.x + this.width &&
-               player.x + player.width > this.x &&
-               player.y < this.y + this.height &&
-               player.y + player.height > this.y;
+        // プレイヤーの中央座標を計算（当たり判定を中央1ピクセルに縮小）
+        const playerCenterX = player.x + player.width / 2;
+        const playerCenterY = player.y + player.height / 2;
+        const hitboxSize = 2; // 当たり判定のサイズ（2x2ピクセル）
+        
+        return playerCenterX - hitboxSize/2 < this.x + this.width &&
+               playerCenterX + hitboxSize/2 > this.x &&
+               playerCenterY - hitboxSize/2 < this.y + this.height &&
+               playerCenterY + hitboxSize/2 > this.y;
     }
 }
 


### PR DESCRIPTION
close: #1

issue #1 対応
- 当たり判定を見た目（40x40）から中央の2x2ピクセルに縮小
- 難易度を下げてプレイしやすくなるよう改善

🤖 Generated with [Claude Code](https://claude.ai/code)